### PR TITLE
Unwrap booleans.

### DIFF
--- a/shared/src/main/scala/eu/unicredit/shocon/SHocon.scala
+++ b/shared/src/main/scala/eu/unicredit/shocon/SHocon.scala
@@ -48,7 +48,10 @@ package object shocon extends Extractors {
       lazy val unwrapped = unwrapStringAsNumber(value).get
     }
     case class StringLiteral(value: String) extends SimpleValue {
-      lazy val unwrapped = unwrapStringAsNumber(value).getOrElse(value)
+      lazy val unwrapped =
+        Try(this.as[Boolean].get)
+          .orElse(unwrapStringAsNumber(value))
+          .getOrElse(value)
     }
     case class BooleanLiteral(value: Boolean) extends SimpleValue {
       lazy val unwrapped = value

--- a/shared/src/test/scala/SHoconGenericSpec.scala
+++ b/shared/src/test/scala/SHoconGenericSpec.scala
@@ -309,6 +309,18 @@ class SHoconGenericSpec {
   }
 
   @Test
+  def unwrappedDuration() = {
+    val map = ConfigFactory.parseString(""" a=2ns """).root.unwrapped
+    assertEquals("2ns", map.get("a")) // Duration is not automatically unwrapped.
+  }
+
+  @Test
+  def unwrappedBoolean() = {
+    val map = ConfigFactory.parseString(""" a=true """).root.unwrapped
+    assertEquals(true, map.get("a"))
+  }
+
+  @Test
   def reparseKey() = {
     val key = "foo.bar.baz"
     val value = shocon.Config.StringLiteral("quux")


### PR DESCRIPTION
I added a negative test for Duration, since typesafe/config does
not automatically unwrap durations.